### PR TITLE
Update stats class and some other QOL changes

### DIFF
--- a/Assets/Scripts/CharacterClass.cs
+++ b/Assets/Scripts/CharacterClass.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
+// TODO: Scrap this class if no `classes` are implemented.
 [CreateAssetMenu(fileName = "class", menuName = "Game/Class", order = 1)]
 public class CharacterClass : ScriptableObject
 {

--- a/Assets/Scripts/Common.cs
+++ b/Assets/Scripts/Common.cs
@@ -4,7 +4,14 @@ using UnityEngine;
 
 public static class Common
 {
-    public static float timedValue(float value) {
+    /// <summary>
+    /// Multiplies a value by Time.deltaTime.
+    /// </summary>
+    /// <param name="value">The velue to multiply, leave empty to get deltaTime.</param>
+    /// <returns>
+    /// float the value multiplied.
+    /// </returns>
+    public static float timedValue(float value = 1f) {
         return (Time.deltaTime * value);
     } 
 

--- a/Assets/Scripts/Player/InputManager.cs
+++ b/Assets/Scripts/Player/InputManager.cs
@@ -4,10 +4,9 @@ using UnityEngine;
 
 public class InputManager : MonoBehaviour
 {
-    [Range(1f, 3f)]
     public PlayerController controller;
-    private float moveX = 0f;
-    private float moveZ = 0f;
+    private Vector3 movement;
+    private bool running = false;
 
     void Update()
     {
@@ -15,23 +14,50 @@ public class InputManager : MonoBehaviour
         this.checkInteract();
     }
 
-    public void checkInteract() {
-        if (Input.GetButtonDown("Jump")) {
-            Debug.Log("interact");
+    /// <summary>
+    /// checks for interactable objects.
+    /// </summary>
+    public void checkInteract()
+    {
+        if (isPressingInteractButton())
+        {
             controller.interact();
         }
     }
-    public void checkMovement() {
-        moveX = Input.GetAxis("Horizontal");
-        moveZ = Input.GetAxis("Vertical"); 
-        Vector3 movement = new Vector3(moveX, 0f, moveZ);
-        if (moveZ != 0f || moveX != 0f) {
+
+    /// <summary>
+    /// Checks if the character should move.
+    /// </summary>
+    public void checkMovement()
+    {
+        running = isPressingRunButton();
+        movement = getAxisValues();
+        if (movement.z != 0f || movement.x != 0f)
+        {
             controller.updateDirection(movement);
         }
-        controller.moveCharacter(movement);
+        controller.moveCharacter(movement, running);
     }
+
     private void Reset()
     {
         this.controller = GetComponent<PlayerController>();
+    }
+
+    // This section must be edited if moving to the new input system
+    // https://forum.unity.com/threads/input-system-update.508660/
+    private bool isPressingRunButton()
+    {
+        return Input.GetButton("Fire3");
+    }
+
+    private bool isPressingInteractButton()
+    {
+        return Input.GetButtonDown("Jump");
+    }
+
+    private Vector3 getAxisValues()
+    {
+        return new Vector3(Input.GetAxis("Horizontal"), 0f, Input.GetAxis("Vertical"));
     }
 }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -11,6 +11,7 @@ public class PlayerController : MonoBehaviour
     private const float interactRadius = 0.8f;
     private GrabableItem grabbedItem;
 
+    /// For debugging purposes only.
     public void OnDrawGizmos()
     {
         // Draw 'Joystick' position (white sphere)
@@ -30,6 +31,10 @@ public class PlayerController : MonoBehaviour
         // Update interactable radius position
         this.interactPosition = this.transform.GetChild(0).position;
     }
+
+    /// <summary>
+    /// Triggers an interaction in the interaction radius.
+    /// </summary>
     public void interact()
     {
         // check for every object in interactable radius
@@ -75,27 +80,44 @@ public class PlayerController : MonoBehaviour
         }
     }
 
-    // Move the character towards joystick position
-    public void moveCharacter(Vector3 speed)
+    /// <summary>
+    /// Move the character towards joystick position.
+    /// </summary>
+    /// <param name="speed">Speed and direction of the movement.</param>
+    /// <param name="running">Is Running?.</param>
+    public void moveCharacter(Vector3 speed, bool running)
     {
-        Vector3 finalSpeed = new Vector3(speed.x * stats.getWalkSpeed(), 0f, speed.z * stats.getWalkSpeed());
+        float multiplier = stats.SPD * (running ? stats.runMultiplier : 1f);
+        Vector3 finalSpeed = new Vector3(speed.x * multiplier, 0f, speed.z * multiplier);
         this.rb.velocity = finalSpeed;
     }
 
-    // Update movement direction
+    /// <summary>
+    /// Updates the character facing direction.
+    /// </summary>
     public void updateDirection(Vector3 direction)
     {
         this.forward = (this.transform.position + direction);
         this.transform.LookAt(this.forward, Vector3.up);
     }
 
-    public Vector3 getThrowVector() {
-        float x = (this.interactPosition.x - this.transform.position.x) * Common.throwForce;
-        float z = (this.interactPosition.z - this.transform.position.z) * Common.throwForce;
-        return new Vector3(x,0f,z);
+    /// <summary>
+    /// Determines the direction and intensity to throw an item.
+    /// </summary>
+    /// <returns>
+    /// Vector3 throw direction.
+    /// </returns>
+    public Vector3 getThrowVector()
+    {
+        return new Vector3(transform.forward.x * Common.throwForce, 0f, transform.forward.z * Common.throwForce);
     }
 
-    // Check if playes has an item
+    /// <summary>
+    /// Determines if the player is holding an item.
+    /// </summary>
+    /// <returns>
+    /// bool true if holding something, otherwise else.
+    /// </returns>
     public bool hasGrabbedItem()
     {
         return (this.grabbedItem != null);

--- a/Assets/Scripts/Player/StatusManager.cs
+++ b/Assets/Scripts/Player/StatusManager.cs
@@ -5,40 +5,46 @@ using UnityEngine;
 public class StatusManager : MonoBehaviour
 {
     public CharacterClass character;
-    private int currentHP;
-    private int maxHP;
-    private float walkSpeed;
-    private float runSpeed;
-    private float slowSpeed;
+    public int currentHP;
+    public int maxHP;
+    public float SPD;
+    public float STR;
+    public float JMP;
+    // TODO: move to Common if going to be standard in al characters.
+    public float runMultiplier = 1.5f;
 
 
+    void Awake()
+    {
+        initialize();
+    }
+
+    /// <summary>
+    /// Initializes the values to the default amount.
+    /// </summary>
     public void initialize()
     {
-        this.currentHP = this.maxHP = this.character.initialHealth;
-        this.walkSpeed = this.character.moveSpeed;
-        this.runSpeed = this.character.runSpeed;
-        this.slowSpeed = this.character.carrySpeed;
+        currentHP = maxHP;
     }
 
-    public float getWalkSpeed() {
-        return this.walkSpeed;
-    }
-
-    public int[] getHp()
-    {
-        return new int[2] { this.currentHP, this.maxHP };
-    }
-
+    /// <summary>
+    /// Changes the current HP value.
+    /// </summary>
+    /// <param name="amount">The amount to add or substract.</param>
     public void changeHP(int amount)
     {
         this.currentHP += amount;
         this.currentHP = (this.currentHP < 0 ? 0 : (this.currentHP > this.maxHP ? this.maxHP : this.currentHP));
-
     }
 
-    // Update is called once per frame
-    void Update()
+    /// <summary>
+    /// Determines if character is dead.
+    /// </summary>
+    /// <returns>
+    /// bool true if current HP = 0, otherwise false.
+    /// </returns>
+    public bool isDead()
     {
-
+        return (currentHP <= 0);
     }
 }

--- a/Assets/Scripts/UI/CameraFollow.cs
+++ b/Assets/Scripts/UI/CameraFollow.cs
@@ -7,7 +7,7 @@ public class CameraFollow : MonoBehaviour
     public float followSpeed = 5f;
     public Vector3 offset = new Vector3(0f, 0f, 0f);
     public Transform follow;
-    // Update is called once per frame
+    
     void Update()
     {
         this.transform.position = Vector3.MoveTowards(this.transform.position, follow.transform.position + offset, Common.timedValue(followSpeed));

--- a/Assets/Scripts/UI/PlayerHud.cs
+++ b/Assets/Scripts/UI/PlayerHud.cs
@@ -8,13 +8,10 @@ public class PlayerHud : MonoBehaviour
     public Camera cam;
     public TMP_Text hpIndicator;
     public StatusManager stats;
-    private int[] Hp;
 
-    // Update is called once per frame
     void Update()
     {
-        Hp = stats.getHp();
-        hpIndicator.text = Hp[0].ToString() + "/" + Hp[1].ToString();
+        hpIndicator.text = stats.currentHP.ToString() + "/" + stats.maxHP.ToString();
         this.transform.position = RectTransformUtility.WorldToScreenPoint(cam, stats.gameObject.transform.position + Vector3.down);
     }
 }

--- a/Assets/_Scenes/SampleScene.unity
+++ b/Assets/_Scenes/SampleScene.unity
@@ -143,7 +143,7 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 62919969}
   serializedVersion: 2
-  m_Mass: 1
+  m_Mass: 5
   m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 1
@@ -265,6 +265,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   character: {fileID: 11400000, guid: 5782303f68f66403f9a67ce062c0a6e2, type: 2}
+  currentHP: 1
+  maxHP: 10
+  SPD: 3
+  STR: 0
+  JMP: 0
+  runMultiplier: 2
 --- !u!1 &122003821
 GameObject:
   m_ObjectHideFlags: 0
@@ -969,13 +975,13 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1042036745}
   serializedVersion: 2
-  m_Mass: 10
+  m_Mass: 200
   m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 112
+  m_Constraints: 80
   m_CollisionDetection: 0
 --- !u!65 &1042036747
 BoxCollider:
@@ -1362,7 +1368,7 @@ GameObject:
   - component: {fileID: 2066151054}
   - component: {fileID: 2066151053}
   m_Layer: 11
-  m_Name: stuff
+  m_Name: Pushable
   m_TagString: grabable
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1394,7 +1400,7 @@ Rigidbody:
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 112
+  m_Constraints: 80
   m_CollisionDetection: 0
 --- !u!65 &2066151055
 BoxCollider:
@@ -1461,10 +1467,10 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2066151052}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: -0.10392088, z: 0, w: 0.9945856}
   m_LocalPosition: {x: -2.32, y: 0.54, z: 0.29526663}
-  m_LocalScale: {x: 0.8, y: 0.5, z: 0.8}
+  m_LocalScale: {x: 0.8, y: 0.8, z: 0.8}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -11.93, z: 0}


### PR DESCRIPTION
## What this PR does
- [x] Implements the HP, SPD, JMP and STR stats in `StatusManager` class
- [x] Add an ignore collision lapse for dropped items to prevent them from falling on top of the player
- [x] Enable Running with Left Shift Key
- [x] `Running` makes some objects to be able to be pushed
- [x] Add wrapper function to input conditions to be able to be refactored later
- [x] Simplifies `GetThrowVector` method of payer controller
- [x] Add doc blocks for many stuff

## What this PR doesn't do
- Decide which objects are pushable, as of today it depends on object's mass set in Rigidbody.
- Add getters and setters for most stats, as they are public.
- Dropped objects still push player away if colliders overlap when the `ignoreCollision` time wears off.

## Something else?
Trello items are updated
